### PR TITLE
copyFile: actually write the data that got read

### DIFF
--- a/caplib.js
+++ b/caplib.js
@@ -176,7 +176,7 @@ function argMap(argv, webkeyStringToLive) {
 
 function copyFile(src, dest) {
     var data = fs.readFileSync(src);
-    fs.writeFileSync(dest);    
+    fs.writeFileSync(dest, data);
 }
 function copyRecurse(src, dest) {
   var exists = fs.existsSync(src);


### PR DESCRIPTION
How did this ever work?

As far as I can tell, `copyFile`, `copyRecurse`, and `makeNewServer` are dead code. Shall I get rid of them?
