### PR TITLE
Proxy.set: return true to indicate success

### DIFF
--- a/saver.js
+++ b/saver.js
@@ -209,6 +209,7 @@ module.exports = function(){
                         }
                     }
                 } else {data[key] = val;} 
+                return true;
             },
             has: function(name) {return name in data;}
             //delete, iterate, keys


### PR DESCRIPTION
mismatch with es6 specs discovered using flow:

> The set method should return a boolean value. Return true to indicate that assignment succeeded.
> --[handler.set() in MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/set)
